### PR TITLE
fix: update NFT marketplace URL to Salvor.io

### DIFF
--- a/src/pages/NFTPage.js
+++ b/src/pages/NFTPage.js
@@ -33,7 +33,7 @@ const NFTPage = () => {
       totalSupply: 89,
       chain: 'Avalanche',
       contract: '0x6d08557830959b3441d269145b32dab93206b3d2',
-      marketplaceUrl: 'https://magiceden.us/collections/avalanche/echoes-by-ultravioleta-dao-806754961',
+      marketplaceUrl: 'https://salvor.io/collections/0x6d08557830959b3441d269145b32dab93206b3d2',
       stats: {
         uniqueOwners: 52,
         listed: 1,


### PR DESCRIPTION
## Summary

Replaces the Magic Eden marketplace URL with Salvor.io for the Echoes by UltraVioleta DAO NFT collection.

## Changes

- `src/pages/NFTPage.js`: updated `marketplaceUrl` from Magic Eden to Salvor.io

## Test plan

- [x] Visit the NFT page and verify the marketplace button links to `https://salvor.io/collections/0x6d08557830959b3441d269145b32dab93206b3d2`
